### PR TITLE
Login, Join error handling

### DIFF
--- a/app/src/main/java/com/mptsix/todaydiary/view/JoinActivity.kt
+++ b/app/src/main/java/com/mptsix/todaydiary/view/JoinActivity.kt
@@ -2,15 +2,20 @@ package com.mptsix.todaydiary.view
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.widget.ArrayAdapter
 import android.widget.Spinner
 import android.widget.Toast
 import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.observe
 import com.mptsix.todaydiary.R
 import com.mptsix.todaydiary.data.request.UserRegisterRequest
 import com.mptsix.todaydiary.databinding.ActivityJoinBinding
 import com.mptsix.todaydiary.viewmodel.LogInViewModel
+import java.lang.RuntimeException
+import java.net.ConnectException
 
 class JoinActivity : AppCompatActivity() {
     lateinit var binding: ActivityJoinBinding
@@ -44,16 +49,42 @@ class JoinActivity : AppCompatActivity() {
                     userPasswordQuestion = userPasswordQuestion,
                     userPasswordAnswer = userPasswordAnswer,
                 )
+                ,{ ->
+
+                    showDialog("Invalid Error", "아이디 비밀번호 규칙이 지켜지지 않았습니다. \n규칙에 맞게 입력해주세요.\n규칙(아이디:이메일, 비밀번호:8자 이상)")
+                    binding.inputJoinID.text = null
+                    binding.inputJoinPwd.text = null
+                },
+                {t:Throwable ->
+                    if(t is ConnectException){
+                        showDialog("Server Error", "서버 상태가 불안정합니다. \n잠시 후에 다시 시도해주세요.")
+                    }
+                    else if(t is RuntimeException){
+                        Toast.makeText(this, "이미 등록된 아이디 입니다. \n다른 아이디를 입력해주세요.", Toast.LENGTH_SHORT).show()
+                        binding.inputJoinID.text=null
+                    }
+                }
             )
         }// 제출 버튼 클릭 시, 담겨져 있는 정보를 변수에 저장하고 현재 activity 종료, ****DB에 저장할 수 있게 변환 필요****
     }
 
+    private fun showDialog(title:String, message: String){
+        val builder: AlertDialog.Builder? = this.let{
+            AlertDialog.Builder(it)
+        }
+        builder?.setMessage(message)
+            ?.setTitle(title)
+            ?.setPositiveButton("확인"){
+                    _, _ ->
+            }
+
+        val dialog:AlertDialog ?= builder?.create()
+        dialog?.show()
+    }
+
     private fun initObserver() {
         logInViewModel.registerSuccess.observe(this) {
-            if (!it) {
-                // Register Failed
-                Toast.makeText(applicationContext, "Something went wrong", Toast.LENGTH_SHORT).show()
-            } else {
+            if(it) {
                 // Register Succeed
                 finish()
             }
@@ -71,5 +102,6 @@ class JoinActivity : AppCompatActivity() {
 
         spinner.adapter = question
     }// 스피너의 바뀐 layout으로 설정하는 adapter
+
 
 }

--- a/app/src/main/java/com/mptsix/todaydiary/view/LoginActivity.kt
+++ b/app/src/main/java/com/mptsix/todaydiary/view/LoginActivity.kt
@@ -10,6 +10,8 @@ import androidx.lifecycle.observe
 import com.mptsix.todaydiary.data.request.LoginRequest
 import com.mptsix.todaydiary.databinding.ActivityLoginBinding
 import com.mptsix.todaydiary.viewmodel.LogInViewModel
+import java.lang.RuntimeException
+import java.net.ConnectException
 
 class LoginActivity : AppCompatActivity() {
     lateinit var binding: ActivityLoginBinding
@@ -33,10 +35,17 @@ class LoginActivity : AppCompatActivity() {
         binding.loginBtn.setOnClickListener {
             val userId :String = binding.inputLoginID.text.toString()
             val userPassword :String = binding.inputLoginPwd.text.toString()
-            logInViewModel.login(LoginRequest(userId, userPassword), {->
-                binding.inputLoginID.text= null
-                binding.inputLoginPwd.text = null
-                Toast.makeText(this, "아이디 혹은 비밀번호를 확인해주세요.", Toast.LENGTH_SHORT).show()
+            logInViewModel.login(LoginRequest(userId, userPassword), { t:Throwable->
+
+                if(t is ConnectException){
+                    Toast.makeText(this, "서버가 불안정합니다.\n잠시 후에 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+                }
+                if(t is RuntimeException){
+                    Toast.makeText(this, "아이디 혹은 비밀번호를 확인해주세요.", Toast.LENGTH_SHORT).show()
+                    binding.inputLoginID.text= null
+                    binding.inputLoginPwd.text = null
+                }
+
 
             })
         }// 로그인 버튼 클릭 시, 담겨져 있는 정보를 가져옴

--- a/app/src/main/java/com/mptsix/todaydiary/view/LoginActivity.kt
+++ b/app/src/main/java/com/mptsix/todaydiary/view/LoginActivity.kt
@@ -2,9 +2,11 @@ package com.mptsix.todaydiary.view
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.observe
 import com.mptsix.todaydiary.data.request.LoginRequest
 import com.mptsix.todaydiary.databinding.ActivityLoginBinding
 import com.mptsix.todaydiary.viewmodel.LogInViewModel
@@ -31,16 +33,18 @@ class LoginActivity : AppCompatActivity() {
         binding.loginBtn.setOnClickListener {
             val userId :String = binding.inputLoginID.text.toString()
             val userPassword :String = binding.inputLoginPwd.text.toString()
-            logInViewModel.login(LoginRequest(userId, userPassword))
+            logInViewModel.login(LoginRequest(userId, userPassword), {->
+                binding.inputLoginID.text= null
+                binding.inputLoginPwd.text = null
+                Toast.makeText(this, "아이디 혹은 비밀번호를 확인해주세요.", Toast.LENGTH_SHORT).show()
+
+            })
         }// 로그인 버튼 클릭 시, 담겨져 있는 정보를 가져옴
     }
 
     private fun initObserver() {
         logInViewModel.loginSuccess.observe(this) {
-            if (!it) {
-                // Login Failed
-                Toast.makeText(applicationContext, "입력한 로그인 정보가 잘못 되었습니다.", Toast.LENGTH_SHORT).show()
-            } else {
+            if(it) {
                 // Login Succeed
                 intent = Intent(this, MainActivity::class.java)
                 startActivity(intent)

--- a/app/src/main/java/com/mptsix/todaydiary/view/LoginActivity.kt
+++ b/app/src/main/java/com/mptsix/todaydiary/view/LoginActivity.kt
@@ -2,7 +2,6 @@ package com.mptsix.todaydiary.view
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -12,6 +11,7 @@ import com.mptsix.todaydiary.databinding.ActivityLoginBinding
 import com.mptsix.todaydiary.viewmodel.LogInViewModel
 import java.lang.RuntimeException
 import java.net.ConnectException
+import java.net.SocketTimeoutException
 
 class LoginActivity : AppCompatActivity() {
     lateinit var binding: ActivityLoginBinding
@@ -35,19 +35,19 @@ class LoginActivity : AppCompatActivity() {
         binding.loginBtn.setOnClickListener {
             val userId :String = binding.inputLoginID.text.toString()
             val userPassword :String = binding.inputLoginPwd.text.toString()
-            logInViewModel.login(LoginRequest(userId, userPassword), { t:Throwable->
-
-                if(t is ConnectException){
-                    Toast.makeText(this, "서버가 불안정합니다.\n잠시 후에 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+            logInViewModel.login(LoginRequest(userId, userPassword)) { t: Throwable ->
+                when (t) {
+                    is ConnectException, is SocketTimeoutException -> Toast.makeText(this, "서버가 불안정합니다.\n잠시 후에 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+                    is RuntimeException -> {
+                        Toast.makeText(this, "아이디 혹은 비밀번호를 확인해주세요.", Toast.LENGTH_SHORT).show()
+                        binding.inputLoginID.text = null
+                        binding.inputLoginPwd.text = null
+                    }
+                    else -> {
+                        Toast.makeText(this, "알 수 없는 에러가 발생했습니다. 메시지: ${t.message}", Toast.LENGTH_SHORT).show()
+                    }
                 }
-                if(t is RuntimeException){
-                    Toast.makeText(this, "아이디 혹은 비밀번호를 확인해주세요.", Toast.LENGTH_SHORT).show()
-                    binding.inputLoginID.text= null
-                    binding.inputLoginPwd.text = null
-                }
-
-
-            })
+            }
         }// 로그인 버튼 클릭 시, 담겨져 있는 정보를 가져옴
     }
 

--- a/app/src/main/java/com/mptsix/todaydiary/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/mptsix/todaydiary/viewmodel/LoginViewModel.kt
@@ -12,11 +12,14 @@ class LogInViewModel: ViewModelHelper() {
     var registerSuccess = MutableLiveData<Boolean>()
 
     //login과 그 결과에 따른 LiveData에 정보 입력
-    fun login(userLoginRequest: LoginRequest){
+    fun login(userLoginRequest: LoginRequest, _onFailure:()->Unit){
         executeServerAndElse(
             serverCallCore = {ServerRepository.loginRequest(userLoginRequest)},
             onSuccess = {loginSuccess.value = (it.userToken != "")},
-            onFailure = {loginSuccess.value = false}
+            onFailure = {
+                _onFailure()
+                loginSuccess.value = false
+            }
         )
     }
 

--- a/app/src/main/java/com/mptsix/todaydiary/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/mptsix/todaydiary/viewmodel/LoginViewModel.kt
@@ -15,12 +15,12 @@ class LogInViewModel: ViewModelHelper() {
     var registerSuccess = MutableLiveData<Boolean>()
 
     //login과 그 결과에 따른 LiveData에 정보 입력
-    fun login(userLoginRequest: LoginRequest, _onFailure:()->Unit){
+    fun login(userLoginRequest: LoginRequest, _onFailure:(t:Throwable)->Unit){
         executeServerAndElse(
             serverCallCore = {ServerRepository.loginRequest(userLoginRequest)},
             onSuccess = {loginSuccess.value = (it.userToken != "")},
             onFailure = {
-                _onFailure()
+                _onFailure(it)
                 loginSuccess.value = false
             }
         )


### PR DESCRIPTION
1. 로그인에서 에러
    a. 서버 불안정시 -> 서버가 불안정합니다. 토스트 메세지로 출력
    b. 로그인 실패시 -> "아이디 혹은 비밀번호를 확인해주세요" 출력 및 id, passwd text 초기화
2. 회원가입에서 에러
    a. 아이디 혹은 비밀번호 형식 일치하지 않을 시 -> dialog로 규칙이 지켜지지 않았다고 notify
    b. 서버 불안정시 -> dialog로 서버가 불안정 하다고 출력
    c. 이미 등록된 아이디 -> 토스트 메세지로 이미 등록된 아이디라고 notify 후 id 입력창 비움
